### PR TITLE
fix: don't keepalive when the connection is busy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+os:
+  - linux
+
+language: go
+
+go:
+  - 1.14.x
+
+env:
+  global:
+    - GOTFLAGS="-race"
+    - BUILD_DEPTYPE=gomod
+
+
+# disable travis install
+install:
+  - true
+
+script:
+  - bash <(curl -s https://raw.githubusercontent.com/ipfs/ci-helpers/master/travis-ci/run-standard-tests.sh)
+
+
+cache:
+  directories:
+    - $GOPATH/pkg/mod
+    - $HOME/.cache/go-build
+
+notifications:
+  email: false

--- a/session.go
+++ b/session.go
@@ -508,6 +508,14 @@ func (s *Session) recvLoop() error {
 			return err
 		}
 
+		// Reset the keepalive timer every time we receive data.
+		// There's no reason to keepalive if we're active. Worse, if the
+		// peer is busy sending us stuff, the pong might get stuck
+		// behind a bunch of data.
+		if s.keepaliveTimer != nil {
+			s.keepaliveTimer.Reset(s.config.KeepAliveInterval)
+		}
+
 		// Verify the version
 		if hdr.Version() != protoVersion {
 			s.logger.Printf("[ERR] yamux: Invalid protocol version: %d", hdr.Version())

--- a/session.go
+++ b/session.go
@@ -304,9 +304,11 @@ func (s *Session) Ping() (time.Duration, error) {
 
 	// Wait for a response
 	start := time.Now()
+	timer := time.NewTimer(s.config.ConnectionWriteTimeout)
+	defer timer.Stop()
 	select {
 	case <-ch:
-	case <-time.After(s.config.ConnectionWriteTimeout):
+	case <-timer.C:
 		s.pingLock.Lock()
 		delete(s.pings, id) // Ignore it if a response comes later.
 		s.pingLock.Unlock()
@@ -316,7 +318,7 @@ func (s *Session) Ping() (time.Duration, error) {
 	}
 
 	// Compute the RTT
-	return time.Now().Sub(start), nil
+	return time.Since(start), nil
 }
 
 // startKeepalive starts the keepalive process.


### PR DESCRIPTION
* It's a waste of bandwidth.
* It causes us to think the connection is dead because the other side is too busy sending us _other_ data to respond to the ping.

fixes #15