### PR TITLE
less head-of-line blocking for control messages

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -47,6 +47,10 @@ type Config struct {
 	// MaxMessageSize is the maximum size of a message that we'll send on a
 	// stream. This ensures that a single stream doesn't hog a connection.
 	MaxMessageSize uint32
+
+	// SendQueueSize is the maximum number of messages we'll keep in the local
+	// send queue before applying back pressure to writers.
+	SendQueueSize uint32
 }
 
 // DefaultConfig is used to return a default configuration
@@ -61,6 +65,7 @@ func DefaultConfig() *Config {
 		ReadBufSize:            4096,
 		MaxMessageSize:         64 * 1024, // Means 64KiB/10s = 52kbps minimum speed.
 		WriteCoalesceDelay:     100 * time.Microsecond,
+		SendQueueSize:          64,
 	}
 }
 

--- a/session_norace_test.go
+++ b/session_norace_test.go
@@ -12,7 +12,13 @@ import (
 )
 
 func TestSession_PingOfDeath(t *testing.T) {
-	client, server := testClientServerConfig(testConfNoKeepAlive())
+	conf := testConfNoKeepAlive()
+	// This test is slow and can easily time out on writes on CI.
+	//
+	// In the future, we might want to prioritize ping-replies over even
+	// other control messages, but that seems like overkill for now.
+	conf.ConnectionWriteTimeout = 1 * time.Second
+	client, server := testClientServerConfig(conf)
 	defer client.Close()
 	defer server.Close()
 

--- a/session_test.go
+++ b/session_test.go
@@ -1197,7 +1197,7 @@ func TestSession_sendMsg_Timeout(t *testing.T) {
 
 	hdr := encode(typePing, flagACK, 0, 0)
 	for {
-		err := client.sendMsg(hdr, nil, nil, nil)
+		err := client.sendMsg(hdr, nil, nil, true)
 		if err == nil {
 			continue
 		} else if err == ErrConnectionWriteTimeout {

--- a/session_test.go
+++ b/session_test.go
@@ -1197,7 +1197,7 @@ func TestSession_sendMsg_Timeout(t *testing.T) {
 
 	hdr := encode(typePing, flagACK, 0, 0)
 	for {
-		err := client.sendMsg(hdr, nil, nil)
+		err := client.sendMsg(hdr, nil, nil, nil)
 		if err == nil {
 			continue
 		} else if err == ErrConnectionWriteTimeout {

--- a/stream.go
+++ b/stream.go
@@ -171,7 +171,7 @@ START:
 
 	// Send the header
 	hdr = encode(typeData, flags, s.id, max)
-	if err = s.session.sendMsg(hdr, b[:max], s.writeDeadline.wait(), s); err != nil {
+	if err = s.session.sendMsg(hdr, b[:max], s.writeDeadline.wait(), false); err != nil {
 		// Indicate queued message.
 		return 0, err
 	}
@@ -231,7 +231,7 @@ func (s *Stream) sendWindowUpdate() error {
 
 	// Send the header
 	hdr := encode(typeWindowUpdate, flags, s.id, delta)
-	if err := s.session.sendMsg(hdr, nil, nil, nil); err != nil {
+	if err := s.session.sendMsg(hdr, nil, nil, true); err != nil {
 		return err
 	}
 	return nil
@@ -242,13 +242,13 @@ func (s *Stream) sendClose() error {
 	flags := s.sendFlags()
 	flags |= flagFIN
 	hdr := encode(typeWindowUpdate, flags, s.id, 0)
-	return s.session.sendMsg(hdr, nil, nil, s)
+	return s.session.sendMsg(hdr, nil, nil, false)
 }
 
 // sendReset is used to send a RST
 func (s *Stream) sendReset() error {
 	hdr := encode(typeWindowUpdate, flagRST, s.id, 0)
-	return s.session.sendMsg(hdr, nil, nil, s)
+	return s.session.sendMsg(hdr, nil, nil, false)
 }
 
 // Reset resets the stream (forcibly closes the stream)
@@ -311,7 +311,7 @@ SEND_CLOSE:
 }
 
 // forceClose is used for when the session is exiting
-func (s *Stream) forceClose(err error) {
+func (s *Stream) forceClose() {
 	s.stateLock.Lock()
 	switch s.state {
 	case streamClosed:

--- a/stream.go
+++ b/stream.go
@@ -6,7 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/libp2p/go-buffer-pool"
+	pool "github.com/libp2p/go-buffer-pool"
 )
 
 type streamState int
@@ -20,6 +20,7 @@ const (
 	streamRemoteClose
 	streamClosed
 	streamReset
+	streamWriteTimeout
 )
 
 // Stream is used to represent a logical stream
@@ -41,6 +42,7 @@ type Stream struct {
 
 	recvNotifyCh chan struct{}
 	sendNotifyCh chan struct{}
+	sendCh       chan []byte
 
 	readDeadline, writeDeadline pipeDeadline
 }
@@ -164,12 +166,13 @@ START:
 	// Determine the flags if any
 	flags = s.sendFlags()
 
-	// Send up to min(message, window
+	// Send up to min(message, window)
 	max = min(window, s.session.config.MaxMessageSize-headerSize, uint32(len(b)))
 
 	// Send the header
 	hdr = encode(typeData, flags, s.id, max)
-	if err = s.session.sendMsg(hdr, b[:max], s.writeDeadline.wait()); err != nil {
+	if err = s.session.sendMsg(hdr, b[:max], s.writeDeadline.wait(), s); err != nil {
+		// Indicate queued message.
 		return 0, err
 	}
 
@@ -228,7 +231,7 @@ func (s *Stream) sendWindowUpdate() error {
 
 	// Send the header
 	hdr := encode(typeWindowUpdate, flags, s.id, delta)
-	if err := s.session.sendMsg(hdr, nil, nil); err != nil {
+	if err := s.session.sendMsg(hdr, nil, nil, nil); err != nil {
 		return err
 	}
 	return nil
@@ -239,13 +242,13 @@ func (s *Stream) sendClose() error {
 	flags := s.sendFlags()
 	flags |= flagFIN
 	hdr := encode(typeWindowUpdate, flags, s.id, 0)
-	return s.session.sendMsg(hdr, nil, nil)
+	return s.session.sendMsg(hdr, nil, nil, s)
 }
 
 // sendReset is used to send a RST
 func (s *Stream) sendReset() error {
 	hdr := encode(typeWindowUpdate, flagRST, s.id, 0)
-	return s.session.sendMsg(hdr, nil, nil)
+	return s.session.sendMsg(hdr, nil, nil, s)
 }
 
 // Reset resets the stream (forcibly closes the stream)
@@ -308,7 +311,7 @@ SEND_CLOSE:
 }
 
 // forceClose is used for when the session is exiting
-func (s *Stream) forceClose() {
+func (s *Stream) forceClose(err error) {
 	s.stateLock.Lock()
 	switch s.state {
 	case streamClosed:


### PR DESCRIPTION
Maintains a parallel `sendCtrlCh` channel of control messages (window updates, pings, new streams) that is drained preferentially over other data queued to send.