### PR TITLE
Revert "re-enable write coalescing"

### DIFF
--- a/session.go
+++ b/session.go
@@ -422,20 +422,25 @@ func (s *Session) sendLoop() error {
 		return nil
 	}
 
-	writer := pool.Writer{W: s.conn}
+	writer := s.conn
 
-	var writeTimeout *time.Timer
-	var writeTimeoutCh <-chan time.Time
-	if s.config.WriteCoalesceDelay > 0 {
-		writeTimeout = time.NewTimer(s.config.WriteCoalesceDelay)
-		defer writeTimeout.Stop()
+	// FIXME: https://github.com/libp2p/go-libp2p/issues/644
+	// Write coalescing is disabled for now.
 
-		writeTimeoutCh = writeTimeout.C
-	} else {
-		ch := make(chan time.Time)
-		close(ch)
-		writeTimeoutCh = ch
-	}
+	//writer := pool.Writer{W: s.conn}
+
+	//var writeTimeout *time.Timer
+	//var writeTimeoutCh <-chan time.Time
+	//if s.config.WriteCoalesceDelay > 0 {
+	//	writeTimeout = time.NewTimer(s.config.WriteCoalesceDelay)
+	//	defer writeTimeout.Stop()
+
+	//	writeTimeoutCh = writeTimeout.C
+	//} else {
+	//	ch := make(chan time.Time)
+	//	close(ch)
+	//	writeTimeoutCh = ch
+	//}
 
 	for {
 		// yield after processing the last message, if we've shutdown.
@@ -453,29 +458,29 @@ func (s *Session) sendLoop() error {
 		case buf = <-s.sendCh:
 		case <-s.shutdownCh:
 			return nil
-		default:
-			select {
-			case buf = <-s.sendCh:
-			case <-s.shutdownCh:
-				return nil
-			case <-writeTimeoutCh:
-				if err := writer.Flush(); err != nil {
-					if os.IsTimeout(err) {
-						err = ErrConnectionWriteTimeout
-					}
-					return err
-				}
+			//default:
+			//	select {
+			//	case buf = <-s.sendCh:
+			//	case <-s.shutdownCh:
+			//		return nil
+			//	case <-writeTimeoutCh:
+			//		if err := writer.Flush(); err != nil {
+			//			if os.IsTimeout(err) {
+			//				err = ErrConnectionWriteTimeout
+			//			}
+			//			return err
+			//		}
 
-				select {
-				case buf = <-s.sendCh:
-				case <-s.shutdownCh:
-					return nil
-				}
+			//		select {
+			//		case buf = <-s.sendCh:
+			//		case <-s.shutdownCh:
+			//			return nil
+			//		}
 
-				if writeTimeout != nil {
-					writeTimeout.Reset(s.config.WriteCoalesceDelay)
-				}
-			}
+			//		if writeTimeout != nil {
+			//			writeTimeout.Reset(s.config.WriteCoalesceDelay)
+			//		}
+			//	}
 		}
 
 		if err := extendWriteDeadline(); err != nil {


### PR DESCRIPTION
This reverts commit 26f5e386a8d28ba5b810ea77e1d83aa6fed1809e.

Keeping write-coalescing off for initial 0.5 release / until additional testing occurs.