### PR TITLE
Clearing inflight along with streams to avoid memory leak

### DIFF
--- a/session.go
+++ b/session.go
@@ -690,6 +690,7 @@ func (s *Session) incomingStream(id uint32) error {
 		// Backlog exceeded! RST the stream
 		s.logger.Printf("[WARN] yamux: backlog exceeded, forcing connection reset")
 		delete(s.streams, id)
+		delete(s.inflight, id)
 		hdr := encode(typeWindowUpdate, flagRST, id, 0)
 		return s.sendMsg(hdr, nil, nil)
 	}
@@ -708,6 +709,7 @@ func (s *Session) closeStream(id uint32) {
 		}
 	}
 	delete(s.streams, id)
+	delete(s.inflight, id)
 	s.streamLock.Unlock()
 }
 


### PR DESCRIPTION
We came across a memory leak issue during a loadtest. Session.inflight was taking around 150MB of space in memory and it was never cleaned up. 

We forked the repo and fixed it by clearing inflight along with the streams. We've tested it under load as well. 

I'd be happy to help to get the PR merged. Let me know if you need anything from me,

This fixes #29 