### PR TITLE
add a context to Open() and OpenStream()

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,6 +1,7 @@
 package yamux
 
 import (
+	"context"
 	"io"
 	"testing"
 )
@@ -37,7 +38,7 @@ func BenchmarkAccept(b *testing.B) {
 	}()
 
 	for i := 0; i < b.N; i++ {
-		stream, err := client.Open()
+		stream, err := client.Open(context.Background())
 		if err != nil {
 			b.Fatalf("err: %v", err)
 		}
@@ -69,7 +70,7 @@ func BenchmarkSendRecv(b *testing.B) {
 		}
 	}()
 
-	stream, err := client.Open()
+	stream, err := client.Open(context.Background())
 	if err != nil {
 		b.Fatalf("err: %v", err)
 	}
@@ -113,7 +114,7 @@ func BenchmarkSendRecvLarge(b *testing.B) {
 		}
 	}()
 
-	stream, err := client.Open()
+	stream, err := client.Open(context.Background())
 	if err != nil {
 		b.Fatalf("err: %v", err)
 	}

--- a/session_norace_test.go
+++ b/session_norace_test.go
@@ -4,6 +4,7 @@ package yamux
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"io/ioutil"
 	"sync"
@@ -93,7 +94,7 @@ func TestSendData_VeryLarge(t *testing.T) {
 	for i := 0; i < workers; i++ {
 		go func() {
 			defer wg.Done()
-			stream, err := client.Open()
+			stream, err := client.Open(context.Background())
 			if err != nil {
 				t.Errorf("err: %v", err)
 				return
@@ -142,7 +143,7 @@ func TestLargeWindow(t *testing.T) {
 	defer client.Close()
 	defer server.Close()
 
-	stream, err := client.Open()
+	stream, err := client.Open(context.Background())
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}


### PR DESCRIPTION
Required for https://github.com/libp2p/go-libp2p-yamux/issues/30.

Since this changes the API, and the current version is v.1.4.1, does this mean this has to be released as a v2.0.0? Is there anything we have to pay attention to when doing so, or is applying the git tag sufficient in this case?