### PR TITLE
don't reimplement io.ReadFull

### DIFF
--- a/util.go
+++ b/util.go
@@ -151,21 +151,10 @@ func (s *segmentedBuffer) Read(b []byte) (int, error) {
 
 func (s *segmentedBuffer) Append(input io.Reader, length int) error {
 	dst := pool.Get(length)
-	n := 0
-	read := 0
-	var err error
-	for n < length && err == nil {
-		read, err = input.Read(dst[n:])
-		n += read
-	}
+	n, err := io.ReadFull(input, dst)
 	if err == io.EOF {
-		if length == n {
-			err = nil
-		} else {
-			err = io.ErrUnexpectedEOF
-		}
+		err = io.ErrUnexpectedEOF
 	}
-
 	s.bm.Lock()
 	defer s.bm.Unlock()
 	if n > 0 {


### PR DESCRIPTION
From the documentation:

> ReadFull reads exactly len(buf) bytes from r into buf. It returns the number of bytes copied and an error if fewer bytes were read. The error is EOF only if no bytes were read. If an EOF happens after reading some but not all the bytes, ReadFull returns ErrUnexpectedEOF. On return, n == len(buf) if and only if err == nil. If r returns an error having read at least len(buf) bytes, the error is dropped.

Not really sure if we need to convert the `io.EOF` to `io.ErrUnexpectedEOF` (only happens if `n == 0`), but this exactly restores the behavior this function had before.