### PR TITLE
remove misleading statement about NAT traversal

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Yamux features include:
 
 * Bi-directional streams
   * Streams can be opened by either client or server
-  * Useful for NAT traversal
   * Server-side push support
 * Flow control
   * Avoid starvation


### PR DESCRIPTION
Maybe this is a misunderstanding on my side, but I don't see how a stream muxer would help with NAT traversal.