### PR TITLE
remove keep-alives

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Yamux features include:
 * Flow control
   * Avoid starvation
   * Back-pressure to prevent overwhelming a receiver
-* Keep Alives
-  * Enables persistent connections over a load balancer
 * Efficient
   * Enables thousands of logical streams with low overhead
 

--- a/const.go
+++ b/const.go
@@ -65,9 +65,6 @@ var (
 	// ErrConnectionWriteTimeout indicates that we hit the "safety valve"
 	// timeout writing to the underlying stream connection.
 	ErrConnectionWriteTimeout = &Error{msg: "connection write timeout", timeout: true}
-
-	// ErrKeepAliveTimeout is sent if a missed keepalive caused the stream close
-	ErrKeepAliveTimeout = &Error{msg: "keepalive timeout", timeout: true}
 )
 
 const (

--- a/mux.go
+++ b/mux.go
@@ -17,13 +17,6 @@ type Config struct {
 	// PingBacklog is used to limit how many ping acks we can queue.
 	PingBacklog int
 
-	// EnableKeepalive is used to do a period keep alive
-	// messages using a ping.
-	EnableKeepAlive bool
-
-	// KeepAliveInterval is how often to perform the keep alive
-	KeepAliveInterval time.Duration
-
 	// ConnectionWriteTimeout is meant to be a "safety valve" timeout after
 	// we which will suspect a problem with the underlying connection and
 	// close it. This is only applied to writes, where's there's generally
@@ -57,8 +50,6 @@ func DefaultConfig() *Config {
 	return &Config{
 		AcceptBacklog:          256,
 		PingBacklog:            32,
-		EnableKeepAlive:        true,
-		KeepAliveInterval:      30 * time.Second,
 		ConnectionWriteTimeout: 10 * time.Second,
 		MaxStreamWindowSize:    initialStreamWindow,
 		LogOutput:              os.Stderr,
@@ -72,9 +63,6 @@ func DefaultConfig() *Config {
 func VerifyConfig(config *Config) error {
 	if config.AcceptBacklog <= 0 {
 		return fmt.Errorf("backlog must be positive")
-	}
-	if config.KeepAliveInterval == 0 {
-		return fmt.Errorf("keep-alive interval must be positive")
 	}
 	if config.MaxStreamWindowSize < initialStreamWindow {
 		return fmt.Errorf("MaxStreamWindowSize must be larger than %d", initialStreamWindow)

--- a/session_norace_test.go
+++ b/session_norace_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestSession_PingOfDeath(t *testing.T) {
-	conf := testConfNoKeepAlive()
+	conf := testConf()
 	// This test is slow and can easily time out on writes on CI.
 	//
 	// In the future, we might want to prioritize ping-replies over even


### PR DESCRIPTION
Fixes #44.

Keeping a connection alive is a responsibility of the underlying transport, not of the stream multiplexer.