### PR TITLE
clean up the receive window check

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -422,15 +422,9 @@ func (s *Stream) readData(hdr header, flags uint16, conn io.Reader) error {
 		return nil
 	}
 
-	// Validate it's okay to copy
-	if !s.recvBuf.TryReserve(length) {
-		s.session.logger.Printf("[ERR] yamux: receive window exceeded (stream: %d, remain: %d, recv: %d)", s.id, s.recvBuf.Cap(), length)
-		return ErrRecvWindowExceeded
-	}
-
 	// Copy into buffer
 	if err := s.recvBuf.Append(conn, length); err != nil {
-		s.session.logger.Printf("[ERR] yamux: Failed to read stream data: %v", err)
+		s.session.logger.Printf("[ERR] yamux: Failed to read stream data on stream %d: %v", s.id, err)
 		return err
 	}
 	// Unblock the reader

--- a/stream.go
+++ b/stream.go
@@ -429,7 +429,7 @@ func (s *Stream) readData(hdr header, flags uint16, conn io.Reader) error {
 	}
 
 	// Copy into buffer
-	if err := s.recvBuf.Append(conn, int(length)); err != nil {
+	if err := s.recvBuf.Append(conn, length); err != nil {
 		s.session.logger.Printf("[ERR] yamux: Failed to read stream data: %v", err)
 		return err
 	}

--- a/util.go
+++ b/util.go
@@ -86,16 +86,6 @@ func (s *segmentedBuffer) Len() uint32 {
 	return s.len
 }
 
-// Cap is the remaining capacity in the receive buffer.
-//
-// Note: this is _not_ the same as go's 'cap' function. The total size of the
-// buffer is len+cap.
-func (s *segmentedBuffer) Cap() uint32 {
-	s.bm.Lock()
-	defer s.bm.Unlock()
-	return s.cap
-}
-
 // If the space to write into + current buffer size has grown to half of the window size,
 // grow up to that max size, and indicate how much additional space was reserved.
 func (s *segmentedBuffer) GrowTo(max uint32, force bool) (bool, uint32) {

--- a/util_test.go
+++ b/util_test.go
@@ -58,7 +58,9 @@ func TestSegmentedBuffer(t *testing.T) {
 		if buf.Len() != len {
 			t.Fatalf("expected length %d, got %d", len, buf.Len())
 		}
-		if buf.Cap() != cap {
+		buf.bm.Lock()
+		defer buf.bm.Unlock()
+		if buf.cap != cap {
 			t.Fatalf("expected length %d, got %d", len, buf.Len())
 		}
 	}

--- a/util_test.go
+++ b/util_test.go
@@ -54,11 +54,11 @@ func TestMin(t *testing.T) {
 
 func TestSegmentedBuffer(t *testing.T) {
 	buf := newSegmentedBuffer(100)
-	assert := func(len, cap int) {
+	assert := func(len, cap uint32) {
 		if buf.Len() != len {
 			t.Fatalf("expected length %d, got %d", len, buf.Len())
 		}
-		if buf.Cap() != uint32(cap) {
+		if buf.Cap() != cap {
 			t.Fatalf("expected length %d, got %d", len, buf.Len())
 		}
 	}

--- a/util_test.go
+++ b/util_test.go
@@ -63,9 +63,6 @@ func TestSegmentedBuffer(t *testing.T) {
 		}
 	}
 	assert(0, 100)
-	if !buf.TryReserve(3) {
-		t.Fatal("reservation should have worked")
-	}
 	if err := buf.Append(bytes.NewReader([]byte("fooo")), 3); err != nil {
 		t.Fatal(err)
 	}
@@ -87,9 +84,6 @@ func TestSegmentedBuffer(t *testing.T) {
 		t.Fatal("should have grown by 2")
 	}
 
-	if !buf.TryReserve(50) {
-		t.Fatal("reservation should have worked")
-	}
 	if err := buf.Append(bytes.NewReader(make([]byte, 50)), 50); err != nil {
 		t.Fatal(err)
 	}
@@ -104,9 +98,7 @@ func TestSegmentedBuffer(t *testing.T) {
 	if read != 50 {
 		t.Fatal("expected to read 50 bytes")
 	}
-	if !buf.TryReserve(49) {
-		t.Fatal("should have been able to reserve rest of space")
-	}
+
 	assert(1, 49)
 	if grew, amount := buf.GrowTo(100, false); !grew || amount != 50 {
 		t.Fatal("should have grown when below half, even with reserved space")


### PR DESCRIPTION
The receive window was performed in `TryReserve`: https://github.com/libp2p/go-yamux/blob/fad228ec42d9796cf26559e4378cd662e4d2c517/util.go#L125-L133
Note the `uint32` overflow.

The only reason this overflow can't be exploited is that it's not possible that `pending` is unequal 0 after calling `Append` (unless `Append` errors, in which case we close the connection anyway). This is the only way we use those two functions: https://github.com/libp2p/go-yamux/blob/fad228ec42d9796cf26559e4378cd662e4d2c517/stream.go#L425-L435

That means that the `pending` member variable is not actually used for anything useful, and can be removed by merging `TryReserve` and `Append`. This is what this PR does.