### PR TITLE
remove misleading comment about the MaxMessageSize

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -63,7 +63,7 @@ func DefaultConfig() *Config {
 		MaxStreamWindowSize:    initialStreamWindow,
 		LogOutput:              os.Stderr,
 		ReadBufSize:            4096,
-		MaxMessageSize:         64 * 1024, // Means 64KiB/10s = 52kbps minimum speed.
+		MaxMessageSize:         64 * 1024,
 		WriteCoalesceDelay:     100 * time.Microsecond,
 	}
 }


### PR DESCRIPTION
Not sure where the 10s come from. Also, the math is slightly wrong.
More importantly, the size of the data frames we send has little to with minimum / maximum transfer speeds.