### PR TITLE
remove unused Stream.Shrink() method

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -740,9 +740,6 @@ func TestManyStreams_PingPong(t *testing.T) {
 				return
 			}
 
-			// Shrink the internal buffer!
-			stream.Shrink()
-
 			// Write out the 'pong'
 			n, err = stream.Write(pong)
 			if err != nil {
@@ -791,9 +788,6 @@ func TestManyStreams_PingPong(t *testing.T) {
 				t.Errorf("bad: %s", buf)
 				return
 			}
-
-			// Shrink the buffer
-			stream.Shrink()
 		}
 	}
 

--- a/stream.go
+++ b/stream.go
@@ -462,7 +462,3 @@ func (s *Stream) SetWriteDeadline(t time.Time) error {
 	}
 	return nil
 }
-
-// Shrink is a no-op. The internal buffer automatically shrinks itself.
-func (s *Stream) Shrink() {
-}


### PR DESCRIPTION
Not sure why we had this method in the first place, it's not a method of our stream interface, and it's not used in libp2p. Should be safe to remove.