### PR TITLE
implement receive window auto tuning

### DIFF
--- a/const.go
+++ b/const.go
@@ -114,7 +114,8 @@ const (
 
 const (
 	// initialStreamWindow is the initial stream window size
-	initialStreamWindow uint32 = 256 * 1024
+	initialStreamWindow uint32 = 64 * 1024
+	maxStreamWindow     uint32 = 16 * 1024 * 1024
 )
 
 const (

--- a/mux.go
+++ b/mux.go
@@ -60,7 +60,7 @@ func DefaultConfig() *Config {
 		EnableKeepAlive:        true,
 		KeepAliveInterval:      30 * time.Second,
 		ConnectionWriteTimeout: 10 * time.Second,
-		MaxStreamWindowSize:    initialStreamWindow,
+		MaxStreamWindowSize:    maxStreamWindow,
 		LogOutput:              os.Stderr,
 		ReadBufSize:            4096,
 		MaxMessageSize:         64 * 1024, // Means 64KiB/10s = 52kbps minimum speed.

--- a/session_norace_test.go
+++ b/session_norace_test.go
@@ -159,7 +159,7 @@ func TestLargeWindow(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	buf := make([]byte, conf.MaxStreamWindowSize)
+	buf := make([]byte, int(initialStreamWindow))
 	n, err := stream.Write(buf)
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/session_test.go
+++ b/session_test.go
@@ -1171,7 +1171,7 @@ func TestSession_PartialReadWindowUpdate(t *testing.T) {
 	wg.Add(1)
 
 	// Choose a huge flood size that we know will result in a window update.
-	flood := int64(client.config.MaxStreamWindowSize)
+	flood := int64(initialStreamWindow)
 	var wr *Stream
 
 	// The server will accept a new stream and then flood data to it.
@@ -1186,8 +1186,8 @@ func TestSession_PartialReadWindowUpdate(t *testing.T) {
 		}
 
 		sendWindow := atomic.LoadUint32(&wr.sendWindow)
-		if sendWindow != client.config.MaxStreamWindowSize {
-			t.Errorf("sendWindow: exp=%d, got=%d", client.config.MaxStreamWindowSize, sendWindow)
+		if sendWindow != initialStreamWindow {
+			t.Errorf("sendWindow: exp=%d, got=%d", initialStreamWindow, sendWindow)
 			return
 		}
 

--- a/session_test.go
+++ b/session_test.go
@@ -1221,8 +1221,9 @@ func TestSession_PartialReadWindowUpdate(t *testing.T) {
 	}
 
 	var (
-		exp        = uint32(flood / 2)
-		sendWindow uint32
+		expWithoutWindowIncrease = uint32(flood / 2)
+		expWithWindowIncrease    = uint32(flood * 3 / 2)
+		sendWindow               uint32
 	)
 
 	// This test is racy. Wait a short period, then longer and longer. At
@@ -1230,11 +1231,11 @@ func TestSession_PartialReadWindowUpdate(t *testing.T) {
 	for i := 1; i < 15; i++ {
 		time.Sleep(time.Duration(i*i) * time.Millisecond)
 		sendWindow = atomic.LoadUint32(&wr.sendWindow)
-		if sendWindow == exp {
+		if sendWindow == expWithoutWindowIncrease || sendWindow == expWithWindowIncrease {
 			return
 		}
 	}
-	t.Errorf("sendWindow: exp=%d, got=%d", exp, sendWindow)
+	t.Errorf("sendWindow: exp=%d or %d, got=%d", expWithoutWindowIncrease, expWithWindowIncrease, sendWindow)
 }
 
 func TestSession_sendMsg_Timeout(t *testing.T) {

--- a/stream.go
+++ b/stream.go
@@ -55,7 +55,7 @@ func newStream(session *Session, id uint32, state streamState) *Stream {
 		sendWindow:    initialStreamWindow,
 		readDeadline:  makePipeDeadline(),
 		writeDeadline: makePipeDeadline(),
-		recvBuf:       newSegmentedBuffer(initialStreamWindow, session.config.MaxStreamWindowSize),
+		recvBuf:       newSegmentedBuffer(initialStreamWindow, session.config.MaxStreamWindowSize, session.getRTT),
 		recvNotifyCh:  make(chan struct{}, 1),
 		sendNotifyCh:  make(chan struct{}, 1),
 	}
@@ -203,7 +203,7 @@ func (s *Stream) sendWindowUpdate() error {
 	flags := s.sendFlags()
 
 	// Update our window
-	needed, delta := s.recvBuf.GrowTo(flags != 0)
+	needed, delta := s.recvBuf.GrowTo(flags != 0, time.Now())
 	if !needed {
 		return nil
 	}

--- a/stream.go
+++ b/stream.go
@@ -55,7 +55,7 @@ func newStream(session *Session, id uint32, state streamState) *Stream {
 		sendWindow:    initialStreamWindow,
 		readDeadline:  makePipeDeadline(),
 		writeDeadline: makePipeDeadline(),
-		recvBuf:       newSegmentedBuffer(initialStreamWindow),
+		recvBuf:       newSegmentedBuffer(initialStreamWindow, session.config.MaxStreamWindowSize),
 		recvNotifyCh:  make(chan struct{}, 1),
 		sendNotifyCh:  make(chan struct{}, 1),
 	}
@@ -202,11 +202,8 @@ func (s *Stream) sendWindowUpdate() error {
 	// Determine the flags if any
 	flags := s.sendFlags()
 
-	// Determine the delta update
-	max := s.session.config.MaxStreamWindowSize
-
 	// Update our window
-	needed, delta := s.recvBuf.GrowTo(max, flags != 0)
+	needed, delta := s.recvBuf.GrowTo(flags != 0)
 	if !needed {
 		return nil
 	}

--- a/util_test.go
+++ b/util_test.go
@@ -53,7 +53,7 @@ func TestMin(t *testing.T) {
 }
 
 func TestSegmentedBuffer(t *testing.T) {
-	buf := newSegmentedBuffer(100)
+	buf := newSegmentedBuffer(100, 100)
 	assert := func(len, cap uint32) {
 		if buf.Len() != len {
 			t.Fatalf("expected length %d, got %d", len, buf.Len())
@@ -79,10 +79,10 @@ func TestSegmentedBuffer(t *testing.T) {
 		t.Fatalf("expected to read 2 bytes, read %d", n)
 	}
 	assert(1, 97)
-	if grew, amount := buf.GrowTo(100, false); grew || amount != 0 {
+	if grew, amount := buf.GrowTo(false); grew || amount != 0 {
 		t.Fatal("should not grow when too small")
 	}
-	if grew, amount := buf.GrowTo(100, true); !grew || amount != 2 {
+	if grew, amount := buf.GrowTo(true); !grew || amount != 2 {
 		t.Fatal("should have grown by 2")
 	}
 
@@ -90,7 +90,7 @@ func TestSegmentedBuffer(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert(51, 49)
-	if grew, amount := buf.GrowTo(100, false); grew || amount != 0 {
+	if grew, amount := buf.GrowTo(false); grew || amount != 0 {
 		t.Fatal("should not grow when data hasn't been read")
 	}
 	read, err := io.CopyN(ioutil.Discard, &buf, 50)
@@ -102,7 +102,7 @@ func TestSegmentedBuffer(t *testing.T) {
 	}
 
 	assert(1, 49)
-	if grew, amount := buf.GrowTo(100, false); !grew || amount != 50 {
+	if grew, amount := buf.GrowTo(false); !grew || amount != 50 {
 		t.Fatal("should have grown when below half, even with reserved space")
 	}
 	assert(1, 99)


### PR DESCRIPTION
Fixes #9.

Based on the algorithm used in QUIC: https://docs.google.com/document/d/1F2YfdDXKpy20WVKJueEf4abn_LVZHhMUMS5gX6Pgjl4/edit#heading=h.hcm2y5x4qmqt.

What we do is compare the frequency we're updating the receive window. Updates happen when we've consumed more than half the available. If we're updating more often than once every 2 RTTs, we double the window size (up to a configurable maximum window size).
Unfortunately, we don't have a good way to get an up-to-date RTT measurement here. Instead, we use the ping function to generate an estimate right when we initialize yamux, and use that estimate for the rest of the connection.