### PR TITLE
set initial window size to spec value (256 kB), remove config option

### DIFF
--- a/const.go
+++ b/const.go
@@ -113,8 +113,9 @@ const (
 )
 
 const (
-	// initialStreamWindow is the initial stream window size
-	initialStreamWindow uint32 = 64 * 1024
+	// initialStreamWindow is the initial stream window size.
+	// It's not an implementation choice, the value defined in the specification.
+	initialStreamWindow uint32 = 256 * 1024
 	maxStreamWindow     uint32 = 16 * 1024 * 1024
 )
 

--- a/mux.go
+++ b/mux.go
@@ -31,10 +31,6 @@ type Config struct {
 	// an expectation that things will move along quickly.
 	ConnectionWriteTimeout time.Duration
 
-	// InitialStreamWindowSize is used to control the initial
-	// window size that we allow for a stream.
-	InitialStreamWindowSize uint32
-
 	// MaxStreamWindowSize is used to control the maximum
 	// window size that we allow for a stream.
 	MaxStreamWindowSize uint32
@@ -60,17 +56,16 @@ type Config struct {
 // DefaultConfig is used to return a default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		AcceptBacklog:           256,
-		PingBacklog:             32,
-		EnableKeepAlive:         true,
-		KeepAliveInterval:       30 * time.Second,
-		ConnectionWriteTimeout:  10 * time.Second,
-		InitialStreamWindowSize: initialStreamWindow,
-		MaxStreamWindowSize:     maxStreamWindow,
-		LogOutput:               os.Stderr,
-		ReadBufSize:             4096,
-		MaxMessageSize:          64 * 1024,
-		WriteCoalesceDelay:      100 * time.Microsecond,
+		AcceptBacklog:          256,
+		PingBacklog:            32,
+		EnableKeepAlive:        true,
+		KeepAliveInterval:      30 * time.Second,
+		ConnectionWriteTimeout: 10 * time.Second,
+		MaxStreamWindowSize:    maxStreamWindow,
+		LogOutput:              os.Stderr,
+		ReadBufSize:            4096,
+		MaxMessageSize:         64 * 1024,
+		WriteCoalesceDelay:     100 * time.Microsecond,
 	}
 }
 
@@ -82,8 +77,8 @@ func VerifyConfig(config *Config) error {
 	if config.KeepAliveInterval == 0 {
 		return fmt.Errorf("keep-alive interval must be positive")
 	}
-	if config.MaxStreamWindowSize < config.InitialStreamWindowSize {
-		return errors.New("MaxStreamWindowSize must be larger than the InitialStreamWindowSize")
+	if config.MaxStreamWindowSize < initialStreamWindow {
+		return errors.New("MaxStreamWindowSize must be larger than the initialStreamWindow (256 kB)")
 	}
 	if config.MaxMessageSize < 1024 {
 		return fmt.Errorf("MaxMessageSize must be greater than a kilobyte")

--- a/session_test.go
+++ b/session_test.go
@@ -1194,7 +1194,7 @@ func TestSession_PartialReadWindowUpdate(t *testing.T) {
 
 		sendWindow := atomic.LoadUint32(&wr.sendWindow)
 		if sendWindow != initialStreamWindow {
-			t.Errorf("sendWindow: exp=%d, got=%d", client.config.InitialStreamWindowSize, sendWindow)
+			t.Errorf("sendWindow: exp=%d, got=%d", initialStreamWindow, sendWindow)
 		}
 
 		n, err := wr.Write(make([]byte, flood))

--- a/stream.go
+++ b/stream.go
@@ -52,7 +52,6 @@ type Stream struct {
 // newStream is used to construct a new stream within
 // a given session for an ID
 func newStream(session *Session, id uint32, state streamState) *Stream {
-	initialStreamWindow := session.config.InitialStreamWindowSize
 	s := &Stream{
 		id:            id,
 		session:       session,


### PR DESCRIPTION
Fixes https://github.com/libp2p/go-libp2p-yamux/issues/36.