### PR TITLE
make the initial stream receive window configurable

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -59,11 +59,14 @@ func newStream(session *Session, id uint32, state streamState) *Stream {
 		sendWindow:    initialStreamWindow,
 		readDeadline:  makePipeDeadline(),
 		writeDeadline: makePipeDeadline(),
-		recvBuf:       newSegmentedBuffer(initialStreamWindow),
-		recvWindow:    initialStreamWindow,
-		epochStart:    time.Now(),
-		recvNotifyCh:  make(chan struct{}, 1),
-		sendNotifyCh:  make(chan struct{}, 1),
+		// Initialize the recvBuf with initialStreamWindow, not config.InitialStreamWindowSize.
+		// The peer isn't allowed to send more data than initialStreamWindow until we've sent
+		// the first window update (which will grant it up to config.InitialStreamWindowSize).
+		recvBuf:      newSegmentedBuffer(initialStreamWindow),
+		recvWindow:   session.config.InitialStreamWindowSize,
+		epochStart:   time.Now(),
+		recvNotifyCh: make(chan struct{}, 1),
+		sendNotifyCh: make(chan struct{}, 1),
 	}
 	return s
 }


### PR DESCRIPTION
While the initial window size is defined by the yamux specification (256 kB), we can just send a window update as soon as a stream is opened / accepted. In fact, that's exactly what we do already.