### PR TITLE
remove call to asyncNotify in Stream.Read

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -83,7 +83,6 @@ func (s *Stream) StreamID() uint32 {
 
 // Read is used to read from the stream
 func (s *Stream) Read(b []byte) (n int, err error) {
-	defer asyncNotify(s.recvNotifyCh)
 START:
 	s.stateLock.Lock()
 	state := s.readState


### PR DESCRIPTION
Stream.Read itself is the only consumer on that channel (assuming no concurrent
calls to this function), so there's nobody else to notify of anything.