### PR TITLE
drastically reduce allocations in ring buffer implementation

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -54,6 +54,7 @@ func BenchmarkSendRecv(b *testing.B) {
 	recvBuf := make([]byte, 512)
 
 	doneCh := make(chan struct{})
+	b.ResetTimer()
 	go func() {
 		defer close(doneCh)
 		defer server.Close()

--- a/util.go
+++ b/util.go
@@ -68,15 +68,16 @@ type segmentedBuffer struct {
 	cap uint32
 	len uint32
 	bm  sync.Mutex
-	// read position in b[0].
+	// read position in b[bPos].
 	// We must not reslice any of the buffers in b, as we need to put them back into the pool.
 	readPos int
+	bPos    int
 	b       [][]byte
 }
 
 // NewSegmentedBuffer allocates a ring buffer.
 func newSegmentedBuffer(initialCapacity uint32) segmentedBuffer {
-	return segmentedBuffer{cap: initialCapacity, b: make([][]byte, 0)}
+	return segmentedBuffer{cap: initialCapacity, b: make([][]byte, 0, 16)}
 }
 
 // Len is the amount of data in the receive buffer.
@@ -109,15 +110,15 @@ func (s *segmentedBuffer) GrowTo(max uint32, force bool) (bool, uint32) {
 func (s *segmentedBuffer) Read(b []byte) (int, error) {
 	s.bm.Lock()
 	defer s.bm.Unlock()
-	if len(s.b) == 0 {
+	if s.bPos == len(s.b) {
 		return 0, io.EOF
 	}
-	data := s.b[0][s.readPos:]
+	data := s.b[s.bPos][s.readPos:]
 	n := copy(b, data)
 	if n == len(data) {
-		pool.Put(s.b[0])
-		s.b[0] = nil
-		s.b = s.b[1:]
+		pool.Put(s.b[s.bPos])
+		s.b[s.bPos] = nil
+		s.bPos++
 		s.readPos = 0
 	} else {
 		s.readPos += n
@@ -152,6 +153,22 @@ func (s *segmentedBuffer) Append(input io.Reader, length uint32) error {
 	if n > 0 {
 		s.len += uint32(n)
 		s.cap -= uint32(n)
+		// we are out of cap
+		if len(s.b) == cap(s.b) && s.bPos > 0 {
+			if s.bPos == len(s.b) {
+				// have no unread chunks, just move pos
+				s.bPos = 0
+				s.b = s.b[:0]
+			} else {
+				// have unread chunks, but also have space at the start of slice, so shift it to the left
+				copied := copy(s.b, s.b[s.bPos:])
+				for i := copied; i < len(s.b); i++ {
+					s.b[i] = nil
+				}
+				s.b = s.b[:copied]
+				s.bPos = 0
+			}
+		}
 		s.b = append(s.b, dst[0:n])
 	}
 	return err

--- a/util.go
+++ b/util.go
@@ -159,7 +159,7 @@ func (s *segmentedBuffer) Append(input io.Reader, length uint32) error {
 				// have no unread chunks, just move pos
 				s.bPos = 0
 				s.b = s.b[:0]
-			} else {
+			} else if s.bPos > cap(s.b)/4 {
 				// have unread chunks, but also have space at the start of slice, so shift it to the left
 				copied := copy(s.b, s.b[s.bPos:])
 				for i := copied; i < len(s.b); i++ {


### PR DESCRIPTION
Reuse cap of `s.b` slice by shifting its elements to the left on writes. Before this change `Append` was allocating a new slice every time because len(s.b) == cap(s.b). In my testings len(s.b) is usually small enough (<= 50, sometimes spikes to 200) even in high-write benchmarks such as BenchmarkSendRecvLarge, often near 0, so copy should not be too expensive. It is also efficient when write rate is roughly equal to read rate.

Tested with
```
$ go version                                                                 
go version go1.16.4 linux/amd64

$ go test -bench=BenchmarkSendRecv -run ^$ -benchmem -benchtime=10s
```

Before
```
goos: linux
goarch: amd64
pkg: github.com/libp2p/go-yamux/v2
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
BenchmarkSendRecv-12         	 4662453	      3042 ns/op	      24 B/op	       1 allocs/op
BenchmarkSendRecvLarge-12    	     163	 121443667 ns/op	  255279 B/op	   10165 allocs/op
PASS
ok  	github.com/libp2p/go-yamux/v2	55.470s
```

After this commit
```
goos: linux
goarch: amd64
pkg: github.com/libp2p/go-yamux/v2
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
BenchmarkSendRecv-12         	 4864972	      2494 ns/op	       0 B/op	       0 allocs/op
BenchmarkSendRecvLarge-12    	     136	  84702011 ns/op	    7162 B/op	       5 allocs/op
PASS
ok  	github.com/libp2p/go-yamux/v2	35.208s
```