### PR TITLE
Remeasure round trip time

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -25,6 +25,9 @@ type Config struct {
 	// KeepAliveInterval is how often to perform the keep alive
 	KeepAliveInterval time.Duration
 
+	// MeasureRTTInterval is how often to re-measure the round trip time
+	MeasureRTTInterval time.Duration
+
 	// ConnectionWriteTimeout is meant to be a "safety valve" timeout after
 	// we which will suspect a problem with the underlying connection and
 	// close it. This is only applied to writes, where's there's generally
@@ -69,6 +72,7 @@ func DefaultConfig() *Config {
 		PingBacklog:             32,
 		EnableKeepAlive:         true,
 		KeepAliveInterval:       30 * time.Second,
+		MeasureRTTInterval:      30 * time.Second,
 		ConnectionWriteTimeout:  10 * time.Second,
 		MaxIncomingStreams:      1000,
 		InitialStreamWindowSize: initialStreamWindow,
@@ -88,6 +92,10 @@ func VerifyConfig(config *Config) error {
 	if config.KeepAliveInterval == 0 {
 		return fmt.Errorf("keep-alive interval must be positive")
 	}
+	if config.MeasureRTTInterval == 0 {
+		return fmt.Errorf("measure-rtt interval must be positive")
+	}
+
 	if config.InitialStreamWindowSize < initialStreamWindow {
 		return errors.New("InitialStreamWindowSize must be larger or equal 256 kB")
 	}

--- a/session.go
+++ b/session.go
@@ -336,7 +336,6 @@ func (s *Session) measureRTT() {
 		return
 	}
 	atomic.StoreInt64(&s.rtt, rtt.Nanoseconds())
-	time.AfterFunc(10*time.Second, s.measureRTT)
 }
 
 // 0 if we don't yet have a measurement
@@ -417,7 +416,8 @@ func (s *Session) startKeepalive() {
 		s.keepaliveActive = true
 		s.keepaliveLock.Unlock()
 
-		_, err := s.Ping()
+		rtt, err := s.Ping()
+		atomic.StoreInt64(&s.rtt, rtt.Nanoseconds())
 
 		s.keepaliveLock.Lock()
 		s.keepaliveActive = false

--- a/session.go
+++ b/session.go
@@ -335,7 +335,11 @@ func (s *Session) measureRTT() {
 	if err != nil {
 		return
 	}
-	atomic.StoreInt64(&s.rtt, rtt.Nanoseconds())
+	if !atomic.CompareAndSwapInt64(&s.rtt, 0, rtt.Nanoseconds()) {
+		prev := atomic.LoadInt64(&s.rtt)
+		smoothedRTT := prev/2 + rtt.Nanoseconds()/2
+		atomic.StoreInt64(&s.rtt, smoothedRTT)
+	}
 }
 
 func (s *Session) startMeasureRTT() {

--- a/session.go
+++ b/session.go
@@ -336,6 +336,7 @@ func (s *Session) measureRTT() {
 		return
 	}
 	atomic.StoreInt64(&s.rtt, rtt.Nanoseconds())
+	time.AfterFunc(10*time.Second, s.measureRTT)
 }
 
 // 0 if we don't yet have a measurement

--- a/session_test.go
+++ b/session_test.go
@@ -239,6 +239,8 @@ func TestPing(t *testing.T) {
 	defer server.Close()
 
 	clientConn := client.conn.(*pipeConn)
+	time.Sleep(time.Millisecond)
+
 	clientConn.BlockWrites()
 	go func() {
 		time.Sleep(10 * time.Millisecond)


### PR DESCRIPTION
# Goals

Keep round trip time up to date. This just updates the measured round trip time any time the keep alive timeout is called.
