### PR TITLE
correctly release memory when the connection is closed

### DIFF
--- a/session.go
+++ b/session.go
@@ -293,8 +293,13 @@ func (s *Session) Close() error {
 
 	s.streamLock.Lock()
 	defer s.streamLock.Unlock()
+	var memory int
 	for _, stream := range s.streams {
+		memory += stream.memory
 		stream.forceClose()
+	}
+	if memory > 0 {
+		s.memoryManager.ReleaseMemory(memory)
 	}
 	return nil
 }
@@ -776,14 +781,14 @@ func (s *Session) incomingStream(id uint32) error {
 		if sendErr := s.sendMsg(s.goAway(goAwayProtoErr), nil, nil); sendErr != nil {
 			s.logger.Printf("[WARN] yamux: failed to send go away: %v", sendErr)
 		}
-		s.memoryManager.ReleaseMemory(initialStreamWindow)
+		s.memoryManager.ReleaseMemory(stream.memory)
 		return ErrDuplicateStream
 	}
 
 	if s.numIncomingStreams >= s.config.MaxIncomingStreams {
 		// too many active streams at the same time
 		s.logger.Printf("[WARN] yamux: MaxIncomingStreams exceeded, forcing stream reset")
-		s.memoryManager.ReleaseMemory(initialStreamWindow)
+		s.memoryManager.ReleaseMemory(stream.memory)
 		hdr := encode(typeWindowUpdate, flagRST, id, 0)
 		return s.sendMsg(hdr, nil, nil)
 	}
@@ -830,7 +835,7 @@ func (s *Session) deleteStream(id uint32) {
 	if !ok {
 		return
 	}
-	s.memoryManager.ReleaseMemory(int(str.recvWindow))
+	s.memoryManager.ReleaseMemory(str.memory)
 	delete(s.streams, id)
 }
 


### PR DESCRIPTION
We still might have open streams, and we need to release memory for those as well.