### PR TITLE
fix flaky TestPing test on Windows

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -241,7 +241,7 @@ func TestPing(t *testing.T) {
 	clientConn := client.conn.(*pipeConn)
 	clientConn.BlockWrites()
 	go func() {
-		time.Sleep(time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
 		clientConn.UnblockWrites()
 	}()
 


### PR DESCRIPTION
Give it a little bit more time, timer resolution on Windows is pretty low.