### PR TITLE
delete streams from the streams map when closing

### DIFF
--- a/session.go
+++ b/session.go
@@ -295,9 +295,10 @@ func (s *Session) Close() error {
 	s.streamLock.Lock()
 	defer s.streamLock.Unlock()
 	var memory int
-	for _, stream := range s.streams {
+	for id, stream := range s.streams {
 		memory += stream.memory
 		stream.forceClose()
+		delete(s.streams, id)
 	}
 	if memory > 0 {
 		s.memoryManager.ReleaseMemory(memory)


### PR DESCRIPTION
This should fix the incorrect memory accounting that users have been reporting (for example https://github.com/filecoin-project/lotus/issues/8632).

There are two actions (at least) that release memory:
* closing / resetting a stream
* closing the connection, which releases the memory for all streams

These can happen concurrently, which is not a problem, as we're holding the `streamLock`. We're also only releasing memory with the resource manager when the stream is still in our streams map.
The condition that made us release too much memory was the following: First, we'd close the session, which would release the memory of all streams. At the same time, the user reset one of the streams. This call would execute once the session is closed and all memory is released. However, since we didn't delete the stream from the map, we'd effectively release the memory allocated for that stream twice.