### PR TITLE
Fix race condition on session Close()

### DIFF
--- a/session.go
+++ b/session.go
@@ -347,10 +347,10 @@ func (s *Session) Close() error {
 
 	s.streamLock.Lock()
 	defer s.streamLock.Unlock()
-	for id, stream := range s.streams {
+	for _, stream := range s.streams {
 		stream.forceClose()
-		delete(s.streams, id)
 	}
+	s.streams = make(map[uint32]*Stream)
 	s.memoryManager.ReleaseAll()
 
 	return nil


### PR DESCRIPTION
This is a proposed fix for libp2p/go-yamux#95.

Instead of accessing the `memory` field of all streams possibly racing with any other goroutines, I would propose wrapping MemoryManager with a goroutine-safe primitive that can track all of the allocated memory and release it on `Close()`.

I've used a lock instead of atomic on `allocated` to prevent races between multiple goroutines trying to allocate/release memory in parallel with `Close()` happening.

cc: @marten-seemann 