### PR TITLE
check deadline before sending a message

### DIFF
--- a/session.go
+++ b/session.go
@@ -490,6 +490,12 @@ func (s *Session) sendMsg(hdr header, body []byte, deadline <-chan struct{}) err
 	default:
 	}
 
+	select {
+	case <-deadline:
+		return ErrTimeout
+	default:
+	}
+
 	// duplicate as we're sending this async.
 	buf := pool.Get(headerSize + len(body))
 	copy(buf[:headerSize], hdr[:])


### PR DESCRIPTION
check deadline before sendMsg, because select is randomly, sometimes it will write successfully after deadline