### PR TITLE
add support for sending error codes on stream reset

### DIFF
--- a/const.go
+++ b/const.go
@@ -57,6 +57,27 @@ func (e *GoAwayError) Is(target error) bool {
 	return false
 }
 
+// A StreamError is used for errors returned from Read and Write calls after the stream is Reset
+type StreamError struct {
+	ErrorCode uint32
+	Remote    bool
+}
+
+func (s *StreamError) Error() string {
+	if s.Remote {
+		return fmt.Sprintf("stream reset by remote, error code: %d", s.ErrorCode)
+	}
+	return fmt.Sprintf("stream reset, error code: %d", s.ErrorCode)
+}
+
+func (s *StreamError) Is(target error) bool {
+	if target == ErrStreamReset {
+		return true
+	}
+	e, ok := target.(*StreamError)
+	return ok && *e == *s
+}
+
 var (
 	// ErrInvalidVersion means we received a frame with an
 	// invalid version

--- a/const.go
+++ b/const.go
@@ -173,7 +173,7 @@ const (
 	// It's not an implementation choice, the value defined in the specification.
 	initialStreamWindow = 256 * 1024
 	maxStreamWindow     = 16 * 1024 * 1024
-	goAwayWaitTime      = 5 * time.Second
+	goAwayWaitTime      = 50 * time.Millisecond
 )
 
 const (

--- a/session.go
+++ b/session.go
@@ -334,7 +334,7 @@ func (s *Session) close(shutdownErr error, sendGoAway bool, errCode uint32) erro
 	s.streamLock.Lock()
 	defer s.streamLock.Unlock()
 	for id, stream := range s.streams {
-		stream.forceClose()
+		stream.forceClose(fmt.Errorf("%w: connection closed: %w", ErrStreamReset, s.shutdownErr))
 		delete(s.streams, id)
 		stream.memorySpan.Done()
 	}


### PR DESCRIPTION
This implements https://github.com/libp2p/specs/pull/622

We use the Length field of a Window Update frame to send an error code on stream reset. This is safe since the window has no meaning post a reset, so existing implementations won't be impacted. 

We cannot send the error in the Data frame as the body there's subject to flow control. 