### PR TITLE
Release v5.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/libp2p/go-yamux/v4
+module github.com/libp2p/go-yamux/v5
 
 go 1.22
 

--- a/session_test.go
+++ b/session_test.go
@@ -1867,3 +1867,10 @@ func TestMaxIncomingStreams(t *testing.T) {
 	_, err = str.Read([]byte{0})
 	require.NoError(t, err)
 }
+
+func TestErrorCodeErrorIsErrStreamReset(t *testing.T) {
+	se := &StreamError{}
+	require.True(t, errors.Is(se, ErrStreamReset))
+	ge := &GoAwayError{}
+	require.True(t, errors.Is(ge, ErrStreamReset))
+}

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v4.0.2"
+  "version": "v5.0.0"
 }


### PR DESCRIPTION
Incrementing the major version since the returned errors are changed and users need to update `err == ErrStreamReset` checks to `errors.Is(err, ErrStreamReset)`
