### PR TITLE
fix: deadlock on close

### DIFF
--- a/const.go
+++ b/const.go
@@ -2,6 +2,7 @@ package yamux
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"time"
 )
@@ -128,6 +129,8 @@ var (
 
 	// ErrKeepAliveTimeout is sent if a missed keepalive caused the stream close
 	ErrKeepAliveTimeout = &Error{msg: "keepalive timeout", timeout: true}
+
+	errSendLoopDone = errors.New("send loop done")
 )
 
 const (

--- a/session.go
+++ b/session.go
@@ -342,7 +342,7 @@ func (s *Session) close(shutdownErr error, sendGoAway bool, errCode uint32) erro
 // GoAway can be used to prevent accepting further
 // connections. It does not close the underlying conn.
 func (s *Session) GoAway() error {
-	return s.sendMsg(s.goAway(goAwayNormal), nil, nil)
+	return s.sendMsg(s.goAway(goAwayNormal), nil, nil, true)
 }
 
 // goAway is used to send a goAway message
@@ -499,7 +499,12 @@ func (s *Session) extendKeepalive() {
 }
 
 // send sends the header and body.
-func (s *Session) sendMsg(hdr header, body []byte, deadline <-chan struct{}) error {
+// If waitForShutDown is true, it will wait for shutdown to complete even if the send loop has exited. This
+// ensures accurate error reporting. waitForShutDown should be true for callers other than the recvLoop.
+// The recvLoop should set waitForShutdown to false to avoid a deadlock.
+// For details see: https://github.com/libp2p/go-yamux/issues/129
+// and the test `TestSessionCloseDeadlock`
+func (s *Session) sendMsg(hdr header, body []byte, deadline <-chan struct{}, waitForShutDown bool) error {
 	select {
 	case <-s.shutdownCh:
 		return s.shutdownErr
@@ -521,6 +526,13 @@ func (s *Session) sendMsg(hdr header, body []byte, deadline <-chan struct{}) err
 	case <-s.shutdownCh:
 		pool.Put(buf)
 		return s.shutdownErr
+	case <-s.sendDoneCh:
+		pool.Put(buf)
+		if waitForShutDown {
+			<-s.shutdownCh
+			return s.shutdownErr
+		}
+		return errSendLoopDone
 	case s.sendCh <- buf:
 		return nil
 	case <-deadline:
@@ -773,9 +785,7 @@ func (s *Session) handleStreamMessage(hdr header) error {
 
 	// Read the new data
 	if err := stream.readData(hdr, flags, s.reader); err != nil {
-		deadline := makePipeDeadline()
-		deadline.set(time.Now().Add(goAwayWaitTime))
-		if sendErr := s.sendMsg(s.goAway(goAwayProtoErr), nil, deadline.wait()); sendErr != nil {
+		if sendErr := s.sendMsg(s.goAway(goAwayProtoErr), nil, nil, false); sendErr != nil && sendErr != errSendLoopDone {
 			s.logger.Printf("[WARN] yamux: failed to send go away: %v", sendErr)
 		}
 		return err
@@ -840,7 +850,7 @@ func (s *Session) incomingStream(id uint32) error {
 	// Reject immediately if we are doing a go away
 	if atomic.LoadInt32(&s.localGoAway) == 1 {
 		hdr := encode(typeWindowUpdate, flagRST, id, 0)
-		return s.sendMsg(hdr, nil, nil)
+		return s.sendMsg(hdr, nil, nil, false)
 	}
 
 	// Allocate a new stream
@@ -859,7 +869,7 @@ func (s *Session) incomingStream(id uint32) error {
 	// Check if stream already exists
 	if _, ok := s.streams[id]; ok {
 		s.logger.Printf("[ERR] yamux: duplicate stream declared")
-		if sendErr := s.sendMsg(s.goAway(goAwayProtoErr), nil, nil); sendErr != nil {
+		if sendErr := s.sendMsg(s.goAway(goAwayProtoErr), nil, nil, false); sendErr != nil && sendErr != errSendLoopDone {
 			s.logger.Printf("[WARN] yamux: failed to send go away: %v", sendErr)
 		}
 		span.Done()
@@ -871,7 +881,7 @@ func (s *Session) incomingStream(id uint32) error {
 		s.logger.Printf("[WARN] yamux: MaxIncomingStreams exceeded, forcing stream reset")
 		defer span.Done()
 		hdr := encode(typeWindowUpdate, flagRST, id, 0)
-		return s.sendMsg(hdr, nil, nil)
+		return s.sendMsg(hdr, nil, nil, false)
 	}
 
 	s.numIncomingStreams++
@@ -888,7 +898,7 @@ func (s *Session) incomingStream(id uint32) error {
 		s.logger.Printf("[WARN] yamux: backlog exceeded, forcing stream reset")
 		s.deleteStream(id)
 		hdr := encode(typeWindowUpdate, flagRST, id, 0)
-		return s.sendMsg(hdr, nil, nil)
+		return s.sendMsg(hdr, nil, nil, false)
 	}
 }
 

--- a/session.go
+++ b/session.go
@@ -773,7 +773,9 @@ func (s *Session) handleStreamMessage(hdr header) error {
 
 	// Read the new data
 	if err := stream.readData(hdr, flags, s.reader); err != nil {
-		if sendErr := s.sendMsg(s.goAway(goAwayProtoErr), nil, nil); sendErr != nil {
+		deadline := makePipeDeadline()
+		deadline.set(time.Now().Add(goAwayWaitTime))
+		if sendErr := s.sendMsg(s.goAway(goAwayProtoErr), nil, deadline.wait()); sendErr != nil {
 			s.logger.Printf("[WARN] yamux: failed to send go away: %v", sendErr)
 		}
 		return err

--- a/stream.go
+++ b/stream.go
@@ -182,7 +182,7 @@ START:
 
 	// Send the header
 	hdr = encode(typeData, flags, s.id, max)
-	if err = s.session.sendMsg(hdr, b[:max], s.writeDeadline.wait()); err != nil {
+	if err = s.session.sendMsg(hdr, b[:max], s.writeDeadline.wait(), true); err != nil {
 		return 0, err
 	}
 
@@ -241,7 +241,7 @@ func (s *Stream) sendWindowUpdate(deadline <-chan struct{}) error {
 
 	s.epochStart = now
 	hdr := encode(typeWindowUpdate, flags, s.id, delta)
-	return s.session.sendMsg(hdr, nil, deadline)
+	return s.session.sendMsg(hdr, nil, deadline, true)
 }
 
 // sendClose is used to send a FIN
@@ -249,13 +249,13 @@ func (s *Stream) sendClose() error {
 	flags := s.sendFlags()
 	flags |= flagFIN
 	hdr := encode(typeWindowUpdate, flags, s.id, 0)
-	return s.session.sendMsg(hdr, nil, nil)
+	return s.session.sendMsg(hdr, nil, nil, true)
 }
 
 // sendReset is used to send a RST
 func (s *Stream) sendReset(errCode uint32) error {
 	hdr := encode(typeWindowUpdate, flagRST, s.id, errCode)
-	return s.session.sendMsg(hdr, nil, nil)
+	return s.session.sendMsg(hdr, nil, nil, true)
 }
 
 // Reset resets the stream (forcibly closes the stream)


### PR DESCRIPTION
Fixes #129 

This PR doesn't include the test case because it's sprinkled with sleep statements and will be prone to be flaky.

I've deployed this change and can confirm that it fixed my issue:

<img width="1253" alt="Screenshot 2025-05-20 at 06 43 37" src="https://github.com/user-attachments/assets/ad89deeb-5906-46d5-9f52-e9552785edc0" />

The lookups don't stall anymore after I've deployed a version of Hermes that uses this fix.