### PR TITLE
fix: scale autotuning threshold proportionally to window size

### DIFF
--- a/autotune_test.go
+++ b/autotune_test.go
@@ -1,0 +1,133 @@
+package yamux
+
+import (
+	"context"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// delayPipe copies from src to dst, adding a one-way delay to each chunk
+// to simulate network latency.
+func delayPipe(dst, src net.Conn, delay time.Duration) {
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := src.Read(buf)
+		if n > 0 {
+			time.Sleep(delay)
+			dst.Write(buf[:n])
+		}
+		if err != nil {
+			dst.Close()
+			return
+		}
+	}
+}
+
+// makeLatencyPair creates a pair of net.Conn with simulated one-way latency
+// in each direction (total RTT = 2 * oneWayDelay).
+func makeLatencyPair(t *testing.T, oneWayDelay time.Duration) (net.Conn, net.Conn) {
+	t.Helper()
+	clientEnd, proxyA := net.Pipe()
+	proxyB, serverEnd := net.Pipe()
+	go delayPipe(proxyB, proxyA, oneWayDelay)
+	go delayPipe(proxyA, proxyB, oneWayDelay)
+	return clientEnd, serverEnd
+}
+
+// TestAutotuningReachesMaxWindow verifies that the receive window grows from
+// InitialStreamWindowSize to MaxStreamWindowSize under sustained throughput
+// with real network latency.
+//
+// Without the scaleFactor fix, the window self-blocks at ~2x the initial size
+// because the fixed 4*RTT threshold doesn't account for the increased time
+// needed to fill a larger window. See https://github.com/libp2p/go-yamux/issues/136
+func TestAutotuningReachesMaxWindow(t *testing.T) {
+	const (
+		initialWindow = 256 * 1024       // 256 KB
+		maxWindow     = 4 * 1024 * 1024  // 4 MB
+		oneWayDelay   = 10 * time.Millisecond // 20ms RTT
+		dataToSend    = 8 * 1024 * 1024  // 8 MB — enough for 4 doublings
+	)
+
+	conf := DefaultConfig()
+	conf.InitialStreamWindowSize = initialWindow
+	conf.MaxStreamWindowSize = maxWindow
+	conf.EnableKeepAlive = false
+	conf.MeasureRTTInterval = 200 * time.Millisecond
+
+	clientConn, serverConn := makeLatencyPair(t, oneWayDelay)
+
+	clientSession, err := Client(clientConn, conf, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientSession.Close()
+
+	serverSession, err := Server(serverConn, conf, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serverSession.Close()
+
+	// Wait for at least one RTT measurement via MeasureRTTInterval.
+	time.Sleep(500 * time.Millisecond)
+
+	// Server goroutine: accept stream and write data.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		stream, err := serverSession.AcceptStream()
+		if err != nil {
+			return
+		}
+		defer stream.Close()
+		chunk := make([]byte, 32*1024)
+		remaining := dataToSend
+		for remaining > 0 {
+			n := len(chunk)
+			if n > remaining {
+				n = remaining
+			}
+			written, err := stream.Write(chunk[:n])
+			remaining -= written
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	// Client: open stream and read all data.
+	stream, err := clientSession.OpenStream(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := make([]byte, 64*1024)
+	totalRead := 0
+	for totalRead < dataToSend {
+		n, err := stream.Read(buf)
+		totalRead += n
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Check window BEFORE closing the stream.
+	finalWindow := stream.recvWindow
+	stream.Close()
+	wg.Wait()
+
+	if finalWindow < maxWindow {
+		t.Errorf("autotuning did not reach max window: got %d KB, want %d KB",
+			finalWindow/1024, maxWindow/1024)
+	}
+	t.Logf("autotuning OK: window grew from %d KB to %d KB",
+		initialWindow/1024, finalWindow/1024)
+}

--- a/stream.go
+++ b/stream.go
@@ -223,18 +223,40 @@ func (s *Stream) sendWindowUpdate(deadline <-chan struct{}) error {
 	}
 
 	now := time.Now()
-	if rtt := s.session.RTT(); flags == 0 && rtt > 0 && now.Sub(s.epochStart) < rtt*4 {
-		var recvWindow uint32
-		if s.recvWindow > math.MaxUint32/2 {
-			recvWindow = min(math.MaxUint32, s.session.config.MaxStreamWindowSize)
-		} else {
-			recvWindow = min(s.recvWindow*2, s.session.config.MaxStreamWindowSize)
+	if rtt := s.session.RTT(); flags == 0 && rtt > 0 {
+		// Scale the autotuning threshold proportionally to the window size.
+		//
+		// The time between consecutive sendWindowUpdate calls includes the time
+		// to transfer ~half the current window of data. As the window grows,
+		// this transfer time grows linearly, but the original fixed 4*RTT
+		// threshold does not — causing autotuning to self-block at roughly 2x
+		// the initial window size on any link with non-trivial latency.
+		//
+		// By scaling the threshold by currentWindow/initialWindow, we allow
+		// proportionally more time for larger windows to fill. At the initial
+		// window size (scaleFactor=1) the behavior is identical to the original.
+		//
+		// See: https://github.com/libp2p/go-yamux/issues/136
+		scaleFactor := time.Duration(s.recvWindow / s.session.config.InitialStreamWindowSize)
+		if scaleFactor < 1 {
+			scaleFactor = 1
 		}
-		if recvWindow > s.recvWindow {
-			grow := recvWindow - s.recvWindow
-			if err := s.memorySpan.ReserveMemory(int(grow), 128); err == nil {
-				s.recvWindow = recvWindow
-				_, delta = s.recvBuf.GrowTo(s.recvWindow, true)
+		if scaleFactor > 64 {
+			scaleFactor = 64
+		}
+		if now.Sub(s.epochStart) < rtt*4*scaleFactor {
+			var recvWindow uint32
+			if s.recvWindow > math.MaxUint32/2 {
+				recvWindow = min(math.MaxUint32, s.session.config.MaxStreamWindowSize)
+			} else {
+				recvWindow = min(s.recvWindow*2, s.session.config.MaxStreamWindowSize)
+			}
+			if recvWindow > s.recvWindow {
+				grow := recvWindow - s.recvWindow
+				if err := s.memorySpan.ReserveMemory(int(grow), 128); err == nil {
+					s.recvWindow = recvWindow
+					_, delta = s.recvBuf.GrowTo(s.recvWindow, true)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes #136.

The `4*RTT` threshold in `sendWindowUpdate()` doesn't scale with window size. As the window grows, filling it takes proportionally longer, but the threshold stays fixed — causing autotuning to self-block at ~2x the initial window size on any link with non-trivial latency.

**Fix:** scale the threshold by `currentWindow / initialWindow`, so larger windows have proportionally more time to fill. At the initial window size (`scaleFactor=1`), the behavior is identical to the original. The scale factor is capped at 64 to bound the threshold.

### Impact (before fix)

| RTT | Stuck Window | Max Throughput | Expected (4 MB max) |
|-----|-------------|----------------|---------------------|
| 50 ms | ~512 KB | ~10 Mbps | 640 Mbps |
| 100 ms | ~512 KB | ~5 Mbps | 320 Mbps |
| 200 ms | ~256 KB | ~1.25 Mbps | 160 Mbps |

### Changes

- **`stream.go`**: in `sendWindowUpdate()`, compute `scaleFactor` from `recvWindow / InitialStreamWindowSize` and use `rtt * 4 * scaleFactor` as the autotuning threshold
- **`autotune_test.go`**: new test that verifies the window grows from `InitialStreamWindowSize` (256 KB) to `MaxStreamWindowSize` (4 MB) with 20 ms simulated RTT. Fails without the fix.

All existing tests pass, including with `-race`.